### PR TITLE
plotPialSurf elecColor bug fix

### DIFF
--- a/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
+++ b/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
@@ -853,6 +853,8 @@ else
     elseif isvector(elecColors) && size(elecColors,2)~=3
         % we need the second condition in case wants to plot a single
         % electrode and passes an rgb vector to specify the color
+        elecColorsAll=elecColors;
+        elecColors=elecColorsAll(showElecIds,:);
         if isnumeric(elecColorScale)
             type='minmax';
             elecCbarMin=elecColorScale(1);
@@ -875,6 +877,8 @@ else
         end
     else
         % elecColorScale consists of a matrix or vector of RGB values
+        elecColorsAll=elecColors;
+        elecColors=elecColorsAll(showElecIds,:);
         if ~universalNo(elecCbar),
             if isnumeric(elecColorScale) && isvector(elecColorScale) && length(elecColorScale)==2
                 elecCbarMin=min(elecColorScale);
@@ -1156,7 +1160,6 @@ function sub_cfg_out=plotPialOmni(fsSub,cfg)
 
 if ~isfield(cfg, 'figId'),         hFig=[];            else  hFig=cfg.figId; end
 if ~isfield(cfg, 'olayThresh'),       olayThresh=[];          else  olayThresh = cfg.olayThresh; end
-if ~isfield(cfg, 'figId'),         hFig=[];              else  hFig=cfg.figId; end
 if ~isfield(cfg, 'fsurfSubDir'),   fsDir=[];             else fsDir=cfg.fsurfSubDir; end
 if ~isfield(cfg, 'elecCoord'),      elecCoord='LEPTO';      else  elecCoord = cfg.elecCoord;       end
 if ~isfield(cfg, 'elecSize'),       elecSize=8;          else  elecSize = cfg.elecSize;      end


### PR DESCRIPTION
Corrects a minor error in plotPialSurf when implementing electrode colors as RGB matrices (and possibly also 1-dimensional "data values" arrays), where the function would "forget" to apply the "left hemisphere/right hemisphere" selection to the colors array (whereas it correctly did so for the coordinates and electrode names).