### PR TITLE
Bug fix electrode size in plotPialOmni

### DIFF
--- a/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
+++ b/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
@@ -1322,7 +1322,7 @@ for h=1:2,
                 sub_cfg.elecCoord='n';
             else
                 sub_cfg.elecCoord=elecCoord;
-                if ~isfield('elecSize',sub_cfg)
+                if ~isfield(sub_cfg,'elecSize')
                     sub_cfg.elecSize=6;
                 end
                 sub_cfg.showLabels=showLabels;
@@ -1332,7 +1332,7 @@ for h=1:2,
                 sub_cfg.elecCoord='n';
             else
                 sub_cfg.elecCoord=elecCoord;
-                if ~isfield('elecSize',sub_cfg)
+                if ~isfield(sub_cfg,'elecSize')
                     sub_cfg.elecSize=6;
                 end
                 sub_cfg.showLabels=showLabels;


### PR DESCRIPTION
This fixes a bug where the elecSize config field would not be correctly passed onto plotPialOmni.