### PR TITLE
plotMgridOnSlices will run also if there is no segmentation file

### DIFF
--- a/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotMgridOnSlices.m
+++ b/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotMgridOnSlices.m
@@ -260,9 +260,14 @@ for elecId=1:nElec,
             axis([tempMin tempMax tempMin tempMax]);
         end
         set(gca,'xtick',[],'ytick',[]);
+                
+        % Get anatomical label if aparc-file exists
+        if exist(fullfile(fsdir,fsSub,'mri','aparc+aseg.mgz'),'file')
+            anatLabel=vox2Seg(xyz(elecId,:),fsSub);
+        else
+            anatLabel = 'NA';
+        end
         
-        anatLabel=vox2Seg(xyz(elecId,:),fsSub);
-  
         % Remove first 3 characters that indicate hemisphere and electrode
         % type
         formattedLabel=elecLabels{elecId}(4:end);


### PR DESCRIPTION
sometimes I want to plot electrodes before the aparc-file is available or I only get the mgrid and the brainmask file from collaborators. 
This function now doesn’t require it  and writes ‘NA’ for anatomical location in the pic title.