### PR TITLE
New option for electrode plotting: cfg.edgeBlack, AND new input option for cfg.edgeBlack

### DIFF
--- a/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotElecs.m
+++ b/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotElecs.m
@@ -110,19 +110,21 @@ else
 end
 
 % Plot Electrodes
-for j = 1:nShowElec,
+for j = 1:nShowElec
     if elecSphere
         sph_ct=sph_ct+1;
         h_elec{sph_ct}=surf(sphX+showElecCoords(j,1),sphY+showElecCoords(j,2),sphZ+showElecCoords(j,3),zeros(Zdim));
         sph_colors(sph_ct,:)=showElecColors(j,:);
     else
         h_elec{j}=plot3(showElecCoords(j,1),showElecCoords(j,2),showElecCoords(j,3),'o','Color',showElecColors(j,:),'MarkerFaceColor', showElecColors(j,:),'MarkerSize',elecSize);
-        if universalYes(edgeBlack),
+        if universalYes(edgeBlack)
+            set(h_elec{j},'MarkerEdgeColor','k');
+        elseif any(strcmp(showElecNames{j},edgeBlack))
             set(h_elec{j},'MarkerEdgeColor','k');
         else
             set(h_elec{j},'MarkerEdgeColor',showElecColors(j,:));
         end
-        if showLabels,
+        if showLabels
             add_name(showElecCoords(j,:),showElecNames{j},showElecNames,elecSize,showElecColors(j,:))
         end
     end

--- a/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotElecs.m
+++ b/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotElecs.m
@@ -1,5 +1,5 @@
-function [showElecCoords, showElecNames, h_elec, elecCbarMin, elecCbarMax, elecCmapName]=plotElecs(elecCoord,surfType,fsDir,fsSub,side,ignoreDepthElec,pullOut,elecColors,elecColorScale,elecShape,elecSize,showLabels,clickElec,elecAssign,edgeBlack,elecNames,elecCbar,bidsDir,bidsSes)
-% function [showElecCoords, showElecNames, h_elec, elecCbarMin, elecCbarMax, elecCmapName]=plotElecs(elecCoord,surfType,fsDir,fsSub,side,ignoreDepthElec,pullOut,elecColors,elecColorScale,elecShape,elecSize,showLabels,clickElec,elecAssign,edgeBlack,elecNames,elecCbar,bidsDir,bidsSes)
+function [showElecCoords, showElecNames, h_elec, elecCbarMin, elecCbarMax, elecCmapName]=plotElecs(elecCoord,surfType,fsDir,fsSub,side,ignoreDepthElec,pullOut,elecColors,elecColorScale,elecShape,elecSize,showLabels,clickElec,elecAssign,edgeBlack,edgeColors,elecNames,elecCbar,bidsDir,bidsSes)
+% function [showElecCoords, showElecNames, h_elec, elecCbarMin, elecCbarMax, elecCmapName]=plotElecs(elecCoord,surfType,fsDir,fsSub,side,ignoreDepthElec,pullOut,elecColors,elecColorScale,elecShape,elecSize,showLabels,clickElec,elecAssign,edgeBlack,edgeColors,elecNames,elecCbar,bidsDir,bidsSes)
 % This function plots electrodes. It should only be called by plotPialSurf.m
 %
 % Inputs:
@@ -117,13 +117,25 @@ for j = 1:nShowElec
         sph_colors(sph_ct,:)=showElecColors(j,:);
     else
         h_elec{j}=plot3(showElecCoords(j,1),showElecCoords(j,2),showElecCoords(j,3),'o','Color',showElecColors(j,:),'MarkerFaceColor', showElecColors(j,:),'MarkerSize',elecSize);
-        if universalYes(edgeBlack)
+        
+        if (iscell(edgeBlack) && max(size(edgeBlack))==1) && universalYes(edgeBlack)...
+                || (ischar(edgeBlack) && universalYes(edgeBlack))
             set(h_elec{j},'MarkerEdgeColor','k');
         elseif any(strcmp(showElecNames{j},edgeBlack))
             set(h_elec{j},'MarkerEdgeColor','k');
         else
             set(h_elec{j},'MarkerEdgeColor',showElecColors(j,:));
         end
+        
+        if ~isempty(edgeColors)
+            [ind1, ~] = match_str(edgeColors(:,1),showElecNames{j});
+            if ~isempty(ind1)
+               set(h_elec{j},'MarkerEdgeColor',edgeColors{ind1,2});
+            end          
+        end
+        
+        
+        
         if showLabels
             add_name(showElecCoords(j,:),showElecNames{j},showElecNames,elecSize,showElecColors(j,:))
         end

--- a/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
+++ b/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
@@ -41,7 +41,10 @@
 %                           border. Otherwise, border will be same color as
 %                           marker. This argument has no effect if
 %                           electrodes are represented as spheres. {default:
-%                           'y'}
+%                           'y'}.
+%                          -Or you can name the labels of the electrodes
+%                          you want black edges drawn for (i.e. cfg.edgeBlack =
+%                          {'LDa1' 'LDa3'};
 %     elecNames            -Cell array of the names of the electrodes to
 %                           show. If elecCoord is a matrix of coordinates,
 %                           the number of names needs to equal the number of

--- a/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
+++ b/iELVis_MAIN/iELVis_MATLAB/PLOTTING/plotPialSurf.m
@@ -42,9 +42,14 @@
 %                           marker. This argument has no effect if
 %                           electrodes are represented as spheres. {default:
 %                           'y'}.
-%                          -Or you can name the labels of the electrodes
-%                          you want black edges drawn for (i.e. cfg.edgeBlack =
-%                          {'LDa1' 'LDa3'};
+%                          -Cell array of electrode names you want black 
+%                           edges drawn for (i.e. cfg.edgeBlack = {'LDa1' 'LDa3'};
+%     edgeColors           -nx2 cell array for electrode label - color 
+%                           combinations for the edges. Colors can be 'r', 
+%                           'g', 'y', 'b', 'k' i.e. {'LDa1' 'k'; 'LDa2' 'y'}.
+%                           Electrodes not mentioned will have a black edge, 
+%                           {default" 'n' which will just do what's defined 
+%                           in edgeBlack}.
 %     elecNames            -Cell array of the names of the electrodes to
 %                           show. If elecCoord is a matrix of coordinates,
 %                           the number of names needs to equal the number of
@@ -388,6 +393,7 @@ if ~isfield(cfg, 'pairs'), elecPairs=[];  else elecPairs=cfg.pairs; end
 if ~isfield(cfg, 'lineWidth'), lineWidth=[];  else lineWidth=cfg.lineWidth; end
 if ~isfield(cfg, 'ignoreDepthElec'), ignoreDepthElec='y'; else ignoreDepthElec=cfg.ignoreDepthElec; end
 if ~isfield(cfg, 'edgeBlack'),      edgeBlack='y';         else edgeBlack=cfg.edgeBlack; end
+if ~isfield(cfg, 'edgeColors'),     edgeColors=[];         else edgeColors=cfg.edgeColors; end
 if ~isfield(cfg, 'elecShape'), elecShape='marker';  else elecShape=cfg.elecShape; end
 if ~isfield(cfg, 'showLabels'), showLabels=0;  else showLabels=universalYes(cfg.showLabels); end
 if ~isfield(cfg, 'opaqueness'),      opaqueness=1;          else opaqueness=cfg.opaqueness; end
@@ -767,7 +773,7 @@ try
     else
         [showElecCoords, showElecNames, h_elec, elecCbarMin, elecCbarMax, elecCmapName]=plotElecs(elecCoord, ...
             surfType,fsDir,fsSub,side,ignoreDepthElec,pullOut,elecColors,elecColorScale, ...
-            elecShape,elecSize,showLabels,clickElec,elecAssign,edgeBlack,elecNames, ...
+            elecShape,elecSize,showLabels,clickElec,elecAssign,edgeBlack,edgeColors,elecNames, ...
             elecCbar,bidsDir,bidsSes);
         plotElecPairs(elecPairs,lineWidth,side,showElecNames,showElecCoords,elecSize);
     end


### PR DESCRIPTION
2 changes:

1) I added a new input option for cfg.edgeBlack. You can now define a cell array with electrodew labels which define which specific electrodes should have a black edge. 

2) A new option cfg.edgeColors:  a nx2 cell array for electrode label - color combinations for edges.  Electrodes not mentioned will have a black edge. 